### PR TITLE
Raise ValueError for invalid percentiles

### DIFF
--- a/dicter/stats.py
+++ b/dicter/stats.py
@@ -46,7 +46,7 @@ class Stats:
     def percentile(self, q: str) -> float:
         arg = str(q)
         if arg not in PERCENTILES:
-            ValueError
+            raise ValueError("Valid percentiles are 5, 10, 25, 50, 75, 90, and 95.")
         return self.percentiles()[arg]
 
     def n(self) -> int:


### PR DESCRIPTION
Previously, an invalid percentile such as 99 would result not in
a ValueError, as the author intended, but instead in a KeyError
since the dictionary returned by the percentiles function only
contains values for keys in the PERCENTILES global constant
(5, 10, 25, 50, 75, 90, and 95).

The ValueError is here raised using Python's raise keyword, and
an explanatory message offers a list of valid percentile values.